### PR TITLE
`globalThis.jQuery = $` を削除

### DIFF
--- a/src/app/entry.js
+++ b/src/app/entry.js
@@ -1,7 +1,5 @@
 "use strict";
 import $ from "jquery";
-globalThis.jQuery = $;
-
 import "bootstrap/dist/js/bootstrap.min.js";
 import "bootstrap/dist/css/bootstrap.min.css";
 


### PR DESCRIPTION
Bootstrap 5 は jQuery に依存しておらず `globalThis.jQuery = $` は不要なため削除します。